### PR TITLE
Update readme to use go install instead of go get

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The simplest, cross-platform way is to download from [GitHub Releases](https://g
 Via Golang package install command
 
 ```sh
-go install github.com/wabarc/go-catbox/cmd/catbox@latest                         
+go install github.com/wabarc/go-catbox/cmd/catbox@latest
 ```
 
 From [gobinaries.com](https://gobinaries.com):

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 
 The simplest, cross-platform way is to download from [GitHub Releases](https://github.com/wabarc/go-catbox/releases) and place the executable file in your PATH.
 
-Via Golang package get command
+Via Golang package install command
 
 ```sh
-go get -u github.com/wabarc/go-catbox/cmd/catbox
+go install github.com/wabarc/go-catbox/cmd/catbox@latest                         
 ```
 
 From [gobinaries.com](https://gobinaries.com):


### PR DESCRIPTION
## Description
<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Switch command to install instead of get to fix:
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.

## Checklist
- [✔️] I have followed the [contributing guidelines](https://github.com/wabarc/.github/blob/main/CONTRIBUTING.md)
- [✔️] I have reviewed and understood the [Code of Conduct](https://github.com/wabarc/.github/blob/main/CODE_OF_CONDUCT.md)
- [✔️] I have searched and make sure there's no duplicate PRs
